### PR TITLE
Fix plugin version in pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <url>https://github.com/jenkinsci/accelq-ci-connect-plugin</url>
     <connection>scm:git:https://github.com/jenkinsci/accelq-ci-connect-plugin.git</connection>
     <developerConnection>scm:git:https://github.com/jenkinsci/accelq-ci-connect-plugin.git</developerConnection>
-    <tag>accelq-ci-connect-1.7</tag>
+    <tag>${scmTag}</tag>
   </scm>
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
   <packaging>hpi</packaging>
 
   <properties>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.version>2.222.3</jenkins.version>
     <java.level>8</java.level>
     <jenkins-test-harness.version>2.71</jenkins-test-harness.version>
@@ -24,9 +25,9 @@
   <description>ACCELQ Continuous Integration</description>
   <url>http://www.accelq.com</url>
   <scm>
-    <url>https://github.com/jenkinsci/accelq-ci-connect-plugin</url>
-    <connection>scm:git:https://github.com/jenkinsci/accelq-ci-connect-plugin.git</connection>
-    <developerConnection>scm:git:https://github.com/jenkinsci/accelq-ci-connect-plugin.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <tag>${scmTag}</tag>
   </scm>
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
     <groupId>com.aq</groupId>
     <artifactId>accelq-ci-connect</artifactId>
-    <version>1.7</version>
+    <version>1.8-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <properties>


### PR DESCRIPTION
## Fix plugin version in pom.xml

- Use scmTag instead of explicitly listing tag value
- Prepare for 1.8 release by setting snapshot version in pom

Changes prepare the plugin for typical development with a SNAPSHOT release in the version field and the tag value inserted by `mvn release:prepare release:perform`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
