### PR TITLE
Require Java 11 and Jenkins 2.361.4 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,14 +72,23 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>[4.5.2,)</version>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
       <version>[1.1.1,)</version>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.16</version>
+    <version>4.71</version>
     <relativePath />
   </parent>
     <groupId>com.aq</groupId>
@@ -15,12 +15,8 @@
   <properties>
     <revision>1.8</revision>
     <changelist>-SNAPSHOT</changelist>
-    <gitHubRepo>jenkinsci/accelq-ci-connect-plugin</gitHubRepo>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.222.3</jenkins.version>
-    <java.level>8</java.level>
-    <jenkins-test-harness.version>2.71</jenkins-test-harness.version>
-    <extn>hpi</extn>
+    <jenkins.version>2.361.4</jenkins.version>
   </properties>
 
   <name>ACCELQ CI-Connect Plugin</name>
@@ -47,7 +43,17 @@
     </license>
   </licenses>
 
-  
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.361.x</artifactId>
+        <version>2102.v854b_fec19c92</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   
   <repositories>
     <repository>


### PR DESCRIPTION
## Require Java 11 and Jenkins 2.361.4 or newer

Jenkins core has required Java 11 since Jenkins 2.361.4 (a year ago).  Vulnerabilities have been reported for older Jenkins versions.  Those vulnerabilities are best fixed by using a newer version of Jenkins.  Using a newer version of Jenkins requires Java 11.  Jenkins tooling uses Java 11.  Update the plugin to use Java 11.

- Require Java 11 and Jenkins 2.361.4 or newer
- Depend on httpcomponents plugin, not library

### Testing done

Confirmed that automated tests run successfully and that the contents of the plugin hpi file look reasonable.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
