### PR TITLE
chore(pom.xml) cleanup markups to allow preparation of incremental builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,15 +8,14 @@
     <version>4.72</version>
     <relativePath />
   </parent>
-    <groupId>com.aq</groupId>
-    <artifactId>accelq-ci-connect</artifactId>
+
+  <groupId>com.aq</groupId>
+  <artifactId>accelq-ci-connect</artifactId>
+  <version>1.8-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <properties>
-    <revision>1.8</revision>
-    <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/accelq-ci-connect-plugin</gitHubRepo>
-    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.version>2.401.3</jenkins.version>
     <java.level>11</java.level>
     <!-- <jenkins-test-harness.version>2.71</jenkins-test-harness.version> -->
@@ -47,8 +46,8 @@
     </license>
   </licenses>
 
-  
-  
+
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3711 and closes https://github.com/jenkinsci/incrementals-tools/issues/73

This PR cleans up the `pom.xml` to allow enablement of incrementals which requires an initial top-level `version` markup to be set following the [`(.+)-SNAPSHOT`](https://github.com/jenkinsci/incrementals-tools/blob/b7f14f3c38905a0844d17eb999a7e751da19bba6/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/IncrementalifyMojo.java#L124) pattern.

It also removes duplicated markup in the `properties` section (as it will be updated by the initial incrementalify call).


## Verification

From the HEAD of this PR, I was able to successully run the `mvn incrementals:incrementalify` command (using JDK11 and Maven 3.9.4) with the following result:

```
$ git status
On branch chore/fix-pom-to-enable-incremental
Your branch is ahead of 'upstream/main' by 1 commit.
  (use "git push" to publish your local commits)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   pom.xml

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        .mvn/

no changes added to commit (use "git add" and/or "git commit -a")
$ git diff
diff --git a/pom.xml b/pom.xml
index 3da9837..05f8e6e 100644
--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,13 @@
 
   <groupId>com.aq</groupId>
   <artifactId>accelq-ci-connect</artifactId>
-  <version>1.8-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
   <properties>
+    <revision>1.8</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/accelq-ci-connect-plugin</gitHubRepo>
     <gitHubRepo>jenkinsci/accelq-ci-connect-plugin</gitHubRepo>
     <jenkins.version>2.401.3</jenkins.version>
     <java.level>11</java.level>
$ cat .mvn/extensions.xml 
<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
  <extension>
    <groupId>io.jenkins.tools.incrementals</groupId>
    <artifactId>git-changelist-maven-extension</artifactId>
    <version>1.7</version>
  </extension>
</extensions>
$ cat .mvn/maven.config 
-Pconsume-incrementals
-Pmight-produce-incrementals
```