### PR TITLE
Logging External URL with Passcode - for non ACCELQ users to still see the results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 buildPlugin(
+  forkCount: '1C',
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 17],
-    [platform: 'windows', jdk: 11],
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])

--- a/src/main/java/com/aq/aqconnect/AQPluginBuilderAction.java
+++ b/src/main/java/com/aq/aqconnect/AQPluginBuilderAction.java
@@ -208,7 +208,7 @@ public class AQPluginBuilderAction extends Recorder implements SimpleBuildStep {
                     if (!jobStatus.equals(AQConstants.TEST_JOB_STATUS.SCHEDULED.getStatus().toUpperCase()) && !hasLoggedLinks) {
                         hasLoggedLinks = true;
                         out.println("Results Link: " + resultAccessURL);
-                        if (!StringUtils.isBlank(jobStatus)) {
+                        if (!StringUtils.isBlank(resultLinkPasscode)) {
                             out.println("Results Link Passcode: " + resultLinkPasscode);
                         }
                         out.println("Need to abort? Click on the link above, login to ACCELQ and abort the run.");
@@ -237,7 +237,7 @@ public class AQPluginBuilderAction extends Recorder implements SimpleBuildStep {
                     && !jobStatus.equals(AQConstants.TEST_JOB_STATUS.FAILED.getStatus().toUpperCase())
                     && !jobStatus.equals(AQConstants.TEST_JOB_STATUS.ERROR.getStatus().toUpperCase()));
             out.println("Results Link: " + resultAccessURL);
-            if (!StringUtils.isBlank(jobStatus)) {
+            if (!StringUtils.isBlank(resultLinkPasscode)) {
                 out.println("Results Link Passcode: " + resultLinkPasscode);
             }
             out.println();

--- a/src/main/java/com/aq/aqconnect/AQRestClient.java
+++ b/src/main/java/com/aq/aqconnect/AQRestClient.java
@@ -47,14 +47,6 @@ public class AQRestClient {
         return BASE_URL;
     }
 
-    public String getResultExternalAccessURL(String jobPid, String tenantCode) {
-        return String.format(getBaseURL() + AQConstants.EXT_JOB_WEB_LINK, tenantCode, jobPid);
-    }
-
-    public String getAbortURL(String jobPid) {
-        return String.format(getBaseURL() + AQConstants.JOB_WEB_LINK, jobPid);
-    }
-
     public void setUpBaseURL(String baseURL, String tenantCode) {
         BASE_URL = baseURL.charAt(baseURL.length() - 1) == '/'?(baseURL):(baseURL + '/');
         API_ENDPOINT =  BASE_URL + "awb/api/" + AQConstants.API_VERSION + "/" + tenantCode;
@@ -136,7 +128,7 @@ public class AQRestClient {
     public JSONObject triggerJob(String apiKey, String userId, String jobId, String runParam, int maxWaitTime) throws IOException,
             ParseException {
         CloseableHttpClient httpClient = getHttpsClient();
-        HttpPut httpPut = new HttpPut(API_ENDPOINT + "/jobs/" + jobId + "/trigger-ci-job");
+        HttpPut httpPut = new HttpPut(API_ENDPOINT + "/jobs/" + jobId + "/trigger-ci-job?passcode=true");
         httpPut.addHeader("User-Agent", AQConstants.USER_AGENT);
         httpPut.addHeader("API_KEY", apiKey);
         httpPut.addHeader("USER_ID", userId);
@@ -152,11 +144,9 @@ public class AQRestClient {
                 response.append(inputLine);
             }
             reader.close();
-            JSONArray jobInfo = (JSONArray) jsonParser.parse(response.toString());
+            JSONObject jobInfo = (JSONObject) jsonParser.parse(response.toString());
             if (httpResponse.getStatusLine().getStatusCode() == 200 || httpResponse.getStatusLine().getStatusCode() == 204) {
-                JSONObject obj = new JSONObject();
-                obj.put("pid", jobInfo.get(0));
-                return obj;
+                return jobInfo;
             } else {
                 // error object
                 return (JSONObject) jsonParser.parse(response.toString());                


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Now for Jenkins Jobs which triggers corresponding ACCELQ Jobs a new Public URL is provided.
This URL allows non-ACCELQ Licensed users to view Results in a read only mode. 


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
